### PR TITLE
Use 'railties' as dependency instead of 'rails'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     md_emoji (0.0.6)
-      rails (>= 3.1.0)
+      railties (>= 3.1.0)
       redcarpet (>= 2.0)
 
 GEM
@@ -97,3 +97,4 @@ PLATFORMS
 DEPENDENCIES
   jquery-rails
   md_emoji!
+  rails (>= 3.1.0)

--- a/lib/md_emoji/engine.rb
+++ b/lib/md_emoji/engine.rb
@@ -1,3 +1,5 @@
+require 'rails/engine'
+
 module MdEmoji
   class Engine < ::Rails::Engine
   end

--- a/md_emoji.gemspec
+++ b/md_emoji.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
     %w{Rakefile README.markdown LICENSE}
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails",     ">= 3.1.0"
+  s.add_dependency "railties",  ">= 3.1.0"
   s.add_dependency "redcarpet", ">= 2.0"
+
+  s.add_development_dependency "rails", ">= 3.1.0"
 end


### PR DESCRIPTION
I'd like to use 'md_emoji' without requiring 'rails'.
Because, 'rails' depend of some gems (such as 'activerecord', 'actionpack', etc).
But 'md_emoji' depend of 'railties' only.

Only to depend on 'railties', it solved.
