### PR TITLE
Emoji should not require a space between them

### DIFF
--- a/lib/md_emoji/render.rb
+++ b/lib/md_emoji/render.rb
@@ -19,7 +19,7 @@ module MdEmoji
     #
     # Valid emoji charaters are listed in +MdEmoji::EMOJI+
     def replace_emoji(text)
-      text.gsub(/:(\S+):/) do |emoji|
+      text.gsub(/:([^\s:])+:/) do |emoji|
 
         emoji_code = emoji #.gsub("|", "_")
         emoji      = emoji_code.gsub(":", "")

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -87,6 +87,15 @@ class RendererTest < ActiveSupport::TestCase
            "<br> not present in parsed text: #{parsed_text}"
   end
 
+  test "works with multiple emoji without spaces" do
+    @markdown = Redcarpet::Markdown.new(MdEmoji::Render.new)
+    text = ":ship::dash:"
+    parsed_text = @markdown.render(text)
+
+    assert_emoji 'ship', parsed_text
+    assert_emoji 'dash', parsed_text
+  end
+
   test "does not render emoji in codeblocks" do
     text = %{```ruby
 def hello


### PR DESCRIPTION
Fixes an issue where having two emoji without spaces wouldn't render those emoji. Specifically something like `:boat::dash:` wouldn't render.

/cc @jordanbyron
